### PR TITLE
fixed bug

### DIFF
--- a/packages/utils/deep-assign.js
+++ b/packages/utils/deep-assign.js
@@ -5,8 +5,7 @@ const { hasOwnProperty } = Object.prototype;
 
 function assignKey(to, from, key) {
   const val = from[key];
-
-  if (!isDef(val) || (hasOwnProperty.call(to, key) && !isDef(to[key]))) {
+  if (!isDef(val)) {
     return;
   }
 


### PR DESCRIPTION
Changes you made in this pull request:

 delete `|| (hasOwnProperty.call(to, key) && !isDef(to[key]))`
目标对象存在key且key为null或者undefined的时候 不copy
